### PR TITLE
Point directly to `Back.png`

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ ZERO_SUIT = [" Sylop"]
 #if we fan out cards stacked on each other, how far apart to fan them?
 CARD_VERTICAL_OFFSET = CARD_HEIGHT * CARD_SCALE * 0.3
 
-FACE_DOWN_IMAGE = "Back.png"
+FACE_DOWN_IMAGE = "cards/Back.png"
 
 class MyGame(arcade.Window):
 


### PR DESCRIPTION
Not sure if this is required on every system since I'm far from a Python expert, but my computer crashed the game until I added the `/cards/` prefix here.